### PR TITLE
Fixed sanitize_file_name filter

### DIFF
--- a/sanitaze-cyrillic.php
+++ b/sanitaze-cyrillic.php
@@ -17,7 +17,7 @@ if (!defined('WPINC')) {
     die;
 }
 
-add_filter('wp_handle_upload_prefilter', 'sanitize_cyrillic_file_name');
+add_filter('sanitize_file_name', 'sanitize_cyrillic_file_name', 10, 2);
 function sanitize_cyrillic_file_name($file)
 {
     preg_match('%\.[^.\\\\/:*?"<>|\r\n]+$%i', $file['name'], $matches);


### PR DESCRIPTION
if wp_handle_upload_prefilter is used russian letters are removed.